### PR TITLE
fix: use electron-builder for native dependency rebuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "neovate",
     "desktop"
   ],
-  "authors": [
-    "chencheng <sorrycc@gmail.com> (https://github.com/sorrycc)"
-  ],
+  "author": "chencheng <sorrycc@gmail.com> (https://github.com/sorrycc)",
   "homepage": "https://neovateai.dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove @electron/rebuild from devDependencies and use electron-builder's built-in install-app-deps command instead.