### PR TITLE
refactor: replace native alerts with toast notifications

### DIFF
--- a/src/renderer/components/AddRepoMenu.tsx
+++ b/src/renderer/components/AddRepoMenu.tsx
@@ -140,7 +140,11 @@ export const AddRepoMenu = ({ children }: AddRepoMenuProps) => {
 
   const handleCloneFromURL = () => {
     setOpen(false);
-    alert('Not implemented');
+    toastManager.add({
+      type: 'info',
+      title: 'Clone from URL',
+      description: 'Clone from URL functionality is not implemented yet',
+    });
   };
 
   return (

--- a/src/renderer/components/WorkspacePanel.tsx
+++ b/src/renderer/components/WorkspacePanel.tsx
@@ -28,6 +28,7 @@ import {
 import { useStore } from '../store';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { Message } from './messages/Message';
+import { toastManager } from './ui/toast';
 import { splitMessages } from './messages/messageHelpers';
 import { OpenAppButton } from './OpenAppButton';
 import { ActivityIndicator } from './ActivityIndicator';
@@ -367,7 +368,11 @@ export const WorkspacePanel = ({
               setIsLoading(false);
             }}
             onShowForkModal={() => {
-              alert('fork not implemented');
+              toastManager.add({
+                type: 'info',
+                title: 'Fork session',
+                description: 'Fork functionality is not implemented yet',
+              });
             }}
             fetchPaths={fetchPaths}
             fetchCommands={fetchCommands}
@@ -415,7 +420,11 @@ WorkspacePanel.Header = function Header() {
   };
 
   const handleCreatePR = () => {
-    alert('Not implemented');
+    toastManager.add({
+      type: 'info',
+      title: 'Create PR',
+      description: 'Create PR functionality is not implemented yet',
+    });
   };
 
   return (

--- a/src/renderer/components/settings/PreferencesPanel.tsx
+++ b/src/renderer/components/settings/PreferencesPanel.tsx
@@ -4,6 +4,7 @@ import { RefreshIcon } from '@hugeicons/core-free-icons';
 import { Button } from '../ui/button';
 import { useStore } from '../../store';
 import { Spinner } from '../ui/spinner';
+import { toastManager } from '../ui/toast';
 
 type ThemeValue = 'light' | 'dark' | 'system';
 
@@ -99,7 +100,11 @@ export const PreferencesPanel = () => {
 
   const handleSendFeedback = () => {
     // Placeholder - will be implemented later
-    alert('Not implemented yet');
+    toastManager.add({
+      type: 'info',
+      title: 'Send feedback',
+      description: 'Send feedback functionality is not implemented yet',
+    });
   };
 
   const handleCheckForUpdates = async () => {
@@ -108,7 +113,11 @@ export const PreferencesPanel = () => {
     // Simulate a brief loading state
     await new Promise((resolve) => setTimeout(resolve, 500));
     setIsCheckingForUpdates(false);
-    alert('Not implemented yet');
+    toastManager.add({
+      type: 'info',
+      title: 'Check for updates',
+      description: 'Check for updates functionality is not implemented yet',
+    });
   };
 
   if (isConfigLoading || globalConfig === null) {

--- a/src/renderer/hooks/useInputHandlers.ts
+++ b/src/renderer/hooks/useInputHandlers.ts
@@ -125,17 +125,23 @@ export function useInputHandlers({
     const trimmed = value.trim();
     if (!trimmed) return;
 
-    // In plan mode, show alert instead of submitting
+    // In plan mode, show toast instead of submitting
     if (planMode === 'plan') {
-      alert('Plan mode is not implemented yet');
+      toastManager.add({
+        type: 'info',
+        title: 'Plan mode',
+        description: 'Plan mode is not implemented yet',
+      });
       return;
     }
 
-    // In memory mode or bash mode, show alert instead of submitting
+    // In memory mode or bash mode, show toast instead of submitting
     if (mode === 'memory' || mode === 'bash') {
-      alert(
-        `${mode.charAt(0).toUpperCase() + mode.slice(1)} mode is not implemented yet`,
-      );
+      toastManager.add({
+        type: 'info',
+        title: `${mode.charAt(0).toUpperCase() + mode.slice(1)} mode`,
+        description: `${mode.charAt(0).toUpperCase() + mode.slice(1)} mode is not implemented yet`,
+      });
       return;
     }
 

--- a/src/renderer/persistence.ts
+++ b/src/renderer/persistence.ts
@@ -1,4 +1,5 @@
 import type { StoreApi } from 'zustand';
+import { toastManager } from './components/ui/toast';
 
 // Declare electron API on window object
 declare global {
@@ -87,9 +88,11 @@ export function setupPersistence(store: StoreApi<any>): void {
       await window.electron.saveStore(persistableState);
     } catch (error) {
       console.error('Failed to save store:', error);
-      window.alert(
-        `Failed to save application state: ${(error as Error).message}`,
-      );
+      toastManager.add({
+        type: 'error',
+        title: 'Failed to save application state',
+        description: (error as Error).message,
+      });
     }
   }, 500);
 

--- a/src/renderer/store.tsx
+++ b/src/renderer/store.tsx
@@ -4,6 +4,7 @@ import { WebSocketTransport } from './client/transport/WebSocketTransport';
 import { MessageBus } from './client/messaging/MessageBus';
 import { randomUUID } from './utils/uuid';
 import { getNestedValue, setNestedValue } from './lib/utils';
+import { toastManager } from './components/ui/toast';
 import type {
   RepoData,
   WorkspaceData,
@@ -604,11 +605,19 @@ const useStore = create<Store>()((set, get) => ({
             }));
             return;
           } else {
-            alert(`${command} Local JSX commands are not supported`);
+            toastManager.add({
+              type: 'error',
+              title: 'Command not supported',
+              description: `${command} Local JSX commands are not supported`,
+            });
           }
           return;
         } else {
-          alert(`${command} Unknown slash command type: ${type}`);
+          toastManager.add({
+            type: 'error',
+            title: 'Unknown command type',
+            description: `${command} Unknown slash command type: ${type}`,
+          });
           return;
         }
       }


### PR DESCRIPTION
Replace native alert() calls with toast notifications

## Problem

The application was using native browser `alert()` dialogs in multiple places, which:
- Blocks the entire UI thread
- Provides poor user experience
- Inconsistent with the existing design system
- Cannot be customized or styled

## Solution

Replaced all `alert()` calls with the existing toast notification system (`toastManager`), which provides:
- Non-blocking notifications
- Consistent design with the rest of the application
- Better user experience
- Support for different notification types (info, error, warning)

## Changes

- `src/renderer/hooks/useInputHandlers.ts`: Replaced alerts for unimplemented modes (plan, memory, bash)
- `src/renderer/store.tsx`: Replaced alerts for slash command errors
- `src/renderer/components/WorkspacePanel.tsx`: Replaced alerts for fork and create PR actions
- `src/renderer/components/AddRepoMenu.tsx`: Replaced alert for clone from URL
- `src/renderer/components/settings/PreferencesPanel.tsx`: Replaced alerts for send feedback and check for updates
- `src/renderer/persistence.ts`: Replaced alert for critical persistence errors

## Impact

- Improved UX: Users can continue interacting with the app while seeing notifications
- Better consistency: All user feedback now uses the same toast system
- No breaking changes: Functionality remains the same, only the notification method changed
- Low risk: Simple replacement, no architectural changes

## Testing

- Verified all alert() calls have been replaced
- Confirmed toast notifications appear correctly for each case
- No linter errors introduced