### PR TITLE
refactor: adjust sidebar collapse behavior and header heights

### DIFF
--- a/src/renderer/components/RepoSidebar.tsx
+++ b/src/renderer/components/RepoSidebar.tsx
@@ -18,6 +18,7 @@ import {
 import { formatDistanceToNowStrict } from 'date-fns';
 import type { RepoData } from '../client/types/entities';
 import { useStore } from '../store';
+import { cn } from '../lib/utils';
 import { Spinner } from './ui/spinner';
 
 // Helper function to format relative time using date-fns
@@ -128,12 +129,14 @@ export const RepoSidebar = ({
 
   return (
     <div
-      className="fixed left-0 top-0 h-screen z-10 flex flex-col w-64 transition-transform duration-200"
+      className={cn(
+        'fixed left-0 top-0 h-screen z-10 flex flex-col transition-all duration-200',
+        sidebarCollapsed ? 'w-12' : 'w-64',
+      )}
       style={{
         backgroundColor: 'var(--bg-surface)',
         color: 'var(--text-primary)',
         borderRight: '1px solid var(--border-subtle)',
-        transform: sidebarCollapsed ? 'translateX(-208px)' : 'translateX(0)',
       }}
     >
       <RepoSidebar.Header
@@ -357,7 +360,9 @@ export const RepoSidebar = ({
         </div>
       )}
 
-      <RepoSidebar.Footer collapsed={sidebarCollapsed} />
+      <div className="mt-auto">
+        <RepoSidebar.Footer collapsed={sidebarCollapsed} />
+      </div>
 
       <Dialog
         open={dialogOpen}
@@ -491,7 +496,10 @@ RepoSidebar.Header = memo(function Header({
 }) {
   return (
     <div
-      className={`flex items-center ${collapsed ? 'justify-end px-2' : 'justify-between px-4'} py-3`}
+      className={cn(
+        'flex items-center h-12',
+        collapsed ? 'justify-end px-2' : 'justify-between px-4',
+      )}
       style={{ borderBottom: '1px solid var(--border-subtle)' }}
     >
       {!collapsed && (
@@ -522,7 +530,10 @@ RepoSidebar.Footer = memo(function Footer({
 
   return (
     <div
-      className={`py-2 flex ${collapsed ? 'flex-col items-end px-2 gap-1' : 'flex-row px-3 gap-2'}`}
+      className={cn(
+        'py-2 flex',
+        collapsed ? 'flex-col items-center px-2 gap-2' : 'flex-row px-3 gap-2',
+      )}
       style={{ borderTop: '1px solid var(--border-subtle)' }}
     >
       <AddRepoMenu>

--- a/src/renderer/components/WorkspacePanel.tsx
+++ b/src/renderer/components/WorkspacePanel.tsx
@@ -466,22 +466,16 @@ WorkspacePanel.Header = function Header() {
 
   return (
     <div
-      className="py-3 px-4"
+      className="flex items-center justify-between h-12 px-4"
       style={{ borderBottom: '1px solid var(--border-subtle)' }}
     >
-      <div className="flex items-center justify-between">
-        <div>
-          <h2
-            className="text-base font-semibold"
-            style={{ color: 'var(--text-primary)' }}
-          >
-            {workspace.id}
-          </h2>
-        </div>
-        <div className="flex gap-2">
-          <OpenAppButton cwd={workspace.worktreePath} request={request} />
-        </div>
-      </div>
+      <h2
+        className="text-base font-semibold"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {workspace.id}
+      </h2>
+      <OpenAppButton cwd={workspace.worktreePath} request={request} />
     </div>
   );
 };


### PR DESCRIPTION
Changed sidebar collapse mechanism from CSS translation to width adjustment and standardized header heights to h-12 for consistent layout across components.

<img width="3498" height="2290" alt="CleanShot 2026-01-10 at 18 07 37@2x" src="https://github.com/user-attachments/assets/4a04f750-e488-4b60-860a-52a0ef97ef96" />
