### PR TITLE
style: replace overflow div with scroll area component

### DIFF
--- a/src/renderer/components/RepoSidebar.tsx
+++ b/src/renderer/components/RepoSidebar.tsx
@@ -19,6 +19,7 @@ import { formatDistanceToNowStrict } from 'date-fns';
 import type { RepoData } from '../client/types/entities';
 import { useStore } from '../store';
 import { Spinner } from './ui/spinner';
+import { ScrollArea } from './ui/scroll-area';
 
 // Helper function to format relative time using date-fns
 function formatRelativeTime(timestamp: number): string {
@@ -142,7 +143,7 @@ export const RepoSidebar = ({
       />
 
       {!sidebarCollapsed && (
-        <div className="flex-1 overflow-y-auto">
+        <ScrollArea className="flex-1" orientation="vertical">
           {repos.length === 0 ? (
             <Empty>
               <EmptyMedia variant="icon">
@@ -354,7 +355,7 @@ export const RepoSidebar = ({
               ))}
             </Accordion>
           )}
-        </div>
+        </ScrollArea>
       )}
 
       <RepoSidebar.Footer collapsed={sidebarCollapsed} />


### PR DESCRIPTION
Replaced native CSS overflow scrollable div with ScrollArea UI component in RepoSidebar for improved cross-platform scrolling behavior and styling consistency.

from this 
![CleanShot 2026-01-10 at 18 11 25](https://github.com/user-attachments/assets/f01a10fa-a865-4a0a-b657-df223520ba35)

to this

![CleanShot 2026-01-10 at 18 12 55](https://github.com/user-attachments/assets/57561f8a-0dd9-47ba-9650-c678acda02f9)
