### PR TITLE
ci: update macos runner to macos-15-intel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,14 +58,17 @@ jobs:
             const arm64 = artifacts.find(a => a.name === 'neovate-dev-arm64');
             const x64 = artifacts.find(a => a.name === 'neovate-dev-x64');
 
+            const artifactUrl = (artifact) => 
+              `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`;
+
             const body = [
               identifier,
               '## 🎉 Build Ready',
               '',
               '| Architecture | Download |',
               '|--------------|----------|',
-              `| Apple Silicon | ${arm64 ? `[Download](${arm64.archive_download_url})` : '⏳'} |`,
-              `| Intel | ${x64 ? `[Download](${x64.archive_download_url})` : '⏳'} |`,
+              `| Apple Silicon | ${arm64 ? `[Download](${artifactUrl(arm64)})` : '⏳'} |`,
+              `| Intel | ${x64 ? `[Download](${artifactUrl(x64)})` : '⏳'} |`,
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
Updated macOS runner in PR workflow from macos-13 to macos-15-intel for x64 architecture builds.