### PR TITLE
feat: add tool approval panel

### DIFF
--- a/docs/designs/2026-01-20-tool-approval-panel.md
+++ b/docs/designs/2026-01-20-tool-approval-panel.md
@@ -1,0 +1,130 @@
+# Tool Approval Panel
+
+**Date:** 2026-01-20
+
+## Context
+
+The goal is to implement a tool approval system for the neovate-code-desktop application, similar to the existing implementation in the takumi project. When the AI agent attempts to use tools that require user permission (like editing files, running bash commands, etc.), the user should be presented with a preview of the action and options to approve or deny.
+
+The reference implementation in takumi uses:
+- `nodeBridge.ts` - Backend sends `toolApproval` requests via MessageBus
+- `uiBridge.ts` - Registers handler that calls store's `approveToolUse`
+- `store.ts` - Contains `approveToolUse` action that returns a Promise
+- `ApprovalModal.tsx` - UI component showing tool preview and approval options
+
+## Discussion
+
+### UI Style Options
+Three approaches were considered:
+1. **Modal Dialog** - Centered overlay that pauses workflow
+2. **Inline Panel** - Appears within the chat/message area (chosen)
+3. **Bottom Sheet** - Slide-up panel from bottom
+
+**Decision:** Inline Panel was selected as it's less disruptive and integrates naturally with the chat flow.
+
+### Approval Options
+Two levels of complexity were considered:
+1. **Full Options** - Approve once, Approve always (for edits/tool), Deny with feedback (chosen)
+2. **Simple Approve/Deny** - Basic yes/no
+
+**Decision:** Full Options to match takumi's functionality and provide power users with workflow optimization.
+
+### Tool Preview Detail
+1. **Rich Previews** - Diff viewer for edits, command preview for bash (chosen)
+2. **Basic Text Only** - Just tool name and parameters
+
+**Decision:** Rich Previews to give users clear understanding of what will be executed.
+
+### Keyboard Handling Issue
+Initial implementation attached `onKeyDown` to a `<div>`, which doesn't work because `<div>` elements aren't focusable by default. Three solutions were considered:
+1. Add `tabIndex` and auto-focus the div
+2. Use global `document.addEventListener('keydown', ...)` (chosen)
+3. Use a focusable element already in the panel
+
+**Decision:** Global event listener via `useEffect` for simplest and most reliable keyboard handling.
+
+## Approach
+
+The implementation follows the takumi pattern but adapts it for the desktop app's architecture:
+
+1. **Session-scoped state** - Approval state lives in the session slice, tied to `selectedSessionId`
+2. **Promise-based flow** - `approveToolUse()` returns a Promise that resolves when user acts
+3. **Inline Panel** - Replaces ChatInput when approval is pending
+4. **Rich previews** - Reuses existing `DiffViewer` component
+
+## Architecture
+
+### Data Flow
+
+```
+Backend: session.send → onToolApprove callback
+    → messageBus.request('toolApproval', {toolUse, category})
+        ↓
+Frontend: MessageBus handler in store/index.ts
+    → store.approveToolUse({sessionId, toolUse, category})
+        → sets approvalBySession[sessionId]
+            → WorkspacePanel detects hasApproval
+                → renders ApprovalPanel instead of ChatInput
+                    → User clicks Approve/Deny
+                        → resolve() clears state
+                            → Promise resolves
+                                → Response sent back to backend
+```
+
+### Files Created
+
+**`src/renderer/components/ApprovalPanel/index.tsx`**
+- Main approval panel component
+- Tool-specific previews:
+  - `edit`/`write` → DiffViewer
+  - `bash` → Command with description
+  - Others → JSON params
+- Approval options: Approve, Approve always, Deny with feedback
+- Global keyboard listener for Esc key
+
+### Files Modified
+
+**`src/renderer/store/slices/session.ts`**
+- Added types: `ApprovalResult`, `ToolUse`, `ApprovalCategory`, `ApprovalModalState`
+- Added state: `approvalBySession: Record<SessionId, ApprovalModalState | null>`
+- Added actions: `approveToolUse()`, `getApproval()`, `clearApproval()`
+
+**`src/renderer/store/index.ts`**
+- Registered `toolApproval` MessageBus handler in `initialize()`
+
+**`src/renderer/components/WorkspacePanel.tsx`**
+- Added `ApprovalPanel` import
+- Added `hasApproval` state check
+- Conditional rendering: ApprovalPanel when pending, ChatInput otherwise
+
+### Key Types
+
+```typescript
+type ApprovalResult =
+  | 'approve_once'
+  | 'approve_always_edit'
+  | 'approve_always_tool'
+  | 'deny';
+
+interface ToolUse {
+  id: string;
+  name: string;
+  params: Record<string, any>;
+}
+
+type ApprovalCategory = 'write' | 'bash' | 'mcp' | 'other';
+
+interface ApprovalModalState {
+  toolUse: ToolUse;
+  category?: ApprovalCategory;
+  resolve: (result: ApprovalResult, params?: Record<string, unknown>) => void;
+}
+```
+
+### Session Config Integration
+
+When user selects "Approve always" options:
+- `approve_always_edit` → Calls `session.config.setApprovalMode` with `autoEdit`
+- `approve_always_tool` → Calls `session.config.addApprovalTools` with tool name
+
+This persists the preference so future uses of that tool/edits don't require approval.

--- a/src/renderer/components/ApprovalPanel/index.tsx
+++ b/src/renderer/components/ApprovalPanel/index.tsx
@@ -1,0 +1,315 @@
+import { useMemo, useState, useCallback, useEffect } from 'react';
+import { useStore } from '../../store';
+import type {
+  ApprovalModalState,
+  ApprovalResult,
+  ApprovalCategory,
+  ToolUse,
+} from '../../store/slices/session';
+import { DiffViewer } from '../messages/DiffViewer';
+import { Button } from '../ui/button';
+
+interface ApprovalPanelProps {
+  sessionId: string;
+  cwd: string;
+}
+
+/**
+ * Inline approval panel that appears in WorkspacePanel when tool approval is needed.
+ * Shows tool preview (diff for edit/write, command for bash) and approval options.
+ */
+function ApprovalPanel({ sessionId, cwd }: ApprovalPanelProps) {
+  const approval = useStore((s) => s.approvalBySession[sessionId]);
+
+  if (!approval) {
+    return null;
+  }
+
+  return (
+    <ApprovalPanelContent approval={approval} sessionId={sessionId} cwd={cwd} />
+  );
+}
+
+interface ApprovalPanelContentProps {
+  approval: ApprovalModalState;
+  sessionId: string;
+  cwd: string;
+}
+
+function ApprovalPanelContent({
+  approval,
+  sessionId,
+  cwd,
+}: ApprovalPanelContentProps) {
+  const [denyReason, setDenyReason] = useState('');
+  const [showDenyInput, setShowDenyInput] = useState(false);
+  const request = useStore((s) => s.request);
+
+  const { toolUse, category, resolve } = approval;
+
+  const handleApprove = useCallback(
+    async (result: ApprovalResult) => {
+      // Handle session config updates for "always" options
+      if (result === 'approve_always_edit') {
+        try {
+          await request('session.config.setApprovalMode', {
+            cwd,
+            sessionId,
+            approvalMode: 'autoEdit',
+          });
+        } catch (e) {
+          console.error('Failed to set approval mode:', e);
+        }
+      } else if (result === 'approve_always_tool') {
+        try {
+          await request('session.config.addApprovalTools', {
+            cwd,
+            sessionId,
+            approvalTool: toolUse.name,
+          });
+        } catch (e) {
+          console.error('Failed to add approval tool:', e);
+        }
+      }
+
+      resolve(result);
+    },
+    [resolve, request, cwd, sessionId, toolUse.name],
+  );
+
+  const handleDeny = useCallback(() => {
+    if (showDenyInput && denyReason.trim()) {
+      resolve('deny', { denyReason: denyReason.trim() });
+    } else if (showDenyInput) {
+      // Empty deny reason, just deny
+      resolve('deny');
+    } else {
+      setShowDenyInput(true);
+    }
+  }, [resolve, showDenyInput, denyReason]);
+
+  // Global keyboard event listener for Esc key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (showDenyInput) {
+          setShowDenyInput(false);
+          setDenyReason('');
+        } else {
+          resolve('deny');
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [showDenyInput, resolve]);
+
+  const title = useMemo(() => getTitle(toolUse, cwd), [toolUse, cwd]);
+  const question = useMemo(() => getQuestionText(toolUse, cwd), [toolUse, cwd]);
+
+  return (
+    <div className="border-t border-(--border-primary) bg-(--bg-surface) p-4">
+      {/* Header */}
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold text-(--text-primary)">{title}</h3>
+      </div>
+
+      {/* Tool Preview */}
+      <div className="mb-4 max-h-80 overflow-auto rounded border border-(--border-secondary) bg-(--bg-base)">
+        <ToolPreview toolUse={toolUse} cwd={cwd} />
+      </div>
+
+      {/* Question */}
+      <div className="mb-3">
+        <p className="text-sm text-(--text-secondary)">{question}</p>
+      </div>
+
+      {/* Deny Input */}
+      {showDenyInput && (
+        <div className="mb-3">
+          <input
+            type="text"
+            className="w-full rounded border border-(--border-primary) bg-(--bg-base) px-3 py-2 text-sm text-(--text-primary) placeholder-(--text-tertiary) focus:border-(--border-focus) focus:outline-none"
+            placeholder="Tell the AI what to do differently..."
+            value={denyReason}
+            onChange={(e) => setDenyReason(e.target.value)}
+            autoFocus
+          />
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="default"
+          onClick={() => handleApprove('approve_once')}
+        >
+          Approve
+        </Button>
+
+        {category === 'write' ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => handleApprove('approve_always_edit')}
+          >
+            Approve all edits this session
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => handleApprove('approve_always_tool')}
+          >
+            Always approve {toolUse.name}
+          </Button>
+        )}
+
+        <Button size="sm" variant="ghost" onClick={handleDeny}>
+          {showDenyInput ? 'Submit feedback' : 'Deny'}
+        </Button>
+      </div>
+
+      {/* Hint */}
+      <div className="mt-2">
+        <p className="text-xs text-(--text-tertiary)">Press Esc to deny</p>
+      </div>
+    </div>
+  );
+}
+
+interface ToolPreviewProps {
+  toolUse: ToolUse;
+  cwd: string;
+}
+
+function ToolPreview({ toolUse, cwd }: ToolPreviewProps) {
+  const { name, params } = toolUse;
+
+  if (name === 'edit' || name === 'write') {
+    return <EditWritePreview toolUse={toolUse} cwd={cwd} />;
+  }
+
+  if (name === 'bash') {
+    return <BashPreview toolUse={toolUse} />;
+  }
+
+  // Generic tool preview
+  return (
+    <div className="p-3">
+      <pre className="text-xs text-(--text-secondary) whitespace-pre-wrap">
+        {JSON.stringify(params, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function EditWritePreview({ toolUse, cwd }: { toolUse: ToolUse; cwd: string }) {
+  const { name, params } = toolUse;
+  const filePath = params.file_path || '';
+
+  // Compute diff content
+  const { originalContent, newContent } = useMemo(() => {
+    // For now, we'll show the new content only since we don't have file system access
+    // In a full implementation, we'd read the original file content
+    if (name === 'edit') {
+      const oldStr = params.old_string || '';
+      const newStr = params.new_string || '';
+      return {
+        originalContent: oldStr,
+        newContent: newStr,
+      };
+    } else {
+      // write tool
+      return {
+        originalContent: '',
+        newContent: params.content || '',
+      };
+    }
+  }, [name, params]);
+
+  const relativePath = useMemo(() => {
+    if (filePath.startsWith(cwd)) {
+      return filePath.slice(cwd.length + 1);
+    }
+    return filePath;
+  }, [filePath, cwd]);
+
+  return (
+    <div className="max-h-64 overflow-auto">
+      <DiffViewer
+        originalContent={originalContent}
+        newContent={newContent}
+        filePath={relativePath}
+      />
+    </div>
+  );
+}
+
+function BashPreview({ toolUse }: { toolUse: ToolUse }) {
+  const { params } = toolUse;
+
+  return (
+    <div className="p-3">
+      <div className="font-mono text-sm text-(--text-primary) bg-(--bg-tertiary) p-2 rounded">
+        $ {params.command}
+      </div>
+      {params.description && (
+        <p className="mt-2 text-xs text-(--text-secondary)">
+          {params.description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function getTitle(toolUse: ToolUse, cwd: string): string {
+  const { name, params } = toolUse;
+
+  if (name === 'edit') {
+    const filePath = params.file_path || '';
+    const relativePath = filePath.startsWith(cwd)
+      ? filePath.slice(cwd.length + 1)
+      : filePath;
+    return `Edit file: ${relativePath}`;
+  }
+
+  if (name === 'write') {
+    const filePath = params.file_path || '';
+    const relativePath = filePath.startsWith(cwd)
+      ? filePath.slice(cwd.length + 1)
+      : filePath;
+    return `Write file: ${relativePath}`;
+  }
+
+  if (name === 'bash') {
+    return 'Run bash command';
+  }
+
+  return `Tool: ${name}`;
+}
+
+function getQuestionText(toolUse: ToolUse, cwd: string): string {
+  const { name, params } = toolUse;
+
+  switch (name) {
+    case 'bash':
+      return 'Do you want to run this command?';
+    case 'edit': {
+      const fileName = (params.file_path || '').split('/').pop() || 'file';
+      return `Do you want to make this edit to ${fileName}?`;
+    }
+    case 'write': {
+      const fileName = (params.file_path || '').split('/').pop() || 'file';
+      return `Do you want to write this file: ${fileName}?`;
+    }
+    default:
+      return 'Do you want to proceed with this action?';
+  }
+}
+
+export { ApprovalPanel };

--- a/src/renderer/components/WorkspacePanel.tsx
+++ b/src/renderer/components/WorkspacePanel.tsx
@@ -20,6 +20,7 @@ import type { SessionData, WorkspaceData } from '../client/types/entities';
 import type { NormalizedMessage } from '../client/types/message';
 import { useStore } from '../store';
 import { ActivityIndicator } from './ActivityIndicator';
+import { ApprovalPanel } from './ApprovalPanel';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { ForkModal } from './ForkModal';
 import { Message } from './messages/Message';
@@ -91,6 +92,12 @@ export const WorkspacePanel = ({
   const showForkModal = useStore((state) => state.showForkModal);
   const hideForkModal = useStore((state) => state.hideForkModal);
   const fork = useStore((state) => state.fork);
+
+  // Get approval state for current session
+  const approvalBySession = useStore((state) => state.approvalBySession);
+  const hasApproval = selectedSessionId
+    ? !!approvalBySession[selectedSessionId]
+    : false;
 
   // Get slash command JSX for current session
   const slashCommandJSX = selectedSessionId
@@ -396,23 +403,31 @@ export const WorkspacePanel = ({
         <WorkspacePanel.Messages />
         <div className="p-4 flex flex-col gap-3">
           <ActivityIndicator sessionId={selectedSessionId} />
-          <ChatInput
-            ref={chatInputRef}
-            onSubmit={sendMessage}
-            onCancel={handleCancel}
-            onShowForkModal={handleShowForkModal}
-            fetchCommands={fetchCommands}
-            placeholder={
-              selectedSessionId
-                ? 'Ask anything, @ for context'
-                : 'Ask anything, @ for context with a new session...'
-            }
-            modelName={workspace.context.settings?.model}
-            isProcessing={isLoading}
-            sessionId={selectedSessionId || undefined}
-            cwd={workspace.repoPath}
-            request={request}
-          />
+          {/* Show ApprovalPanel when there's a pending approval, otherwise show ChatInput */}
+          {hasApproval && selectedSessionId ? (
+            <ApprovalPanel
+              sessionId={selectedSessionId}
+              cwd={workspace.worktreePath}
+            />
+          ) : (
+            <ChatInput
+              ref={chatInputRef}
+              onSubmit={sendMessage}
+              onCancel={handleCancel}
+              onShowForkModal={handleShowForkModal}
+              fetchCommands={fetchCommands}
+              placeholder={
+                selectedSessionId
+                  ? 'Ask anything, @ for context'
+                  : 'Ask anything, @ for context with a new session...'
+              }
+              modelName={workspace.context.settings?.model}
+              isProcessing={isLoading}
+              sessionId={selectedSessionId || undefined}
+              cwd={workspace.repoPath}
+              request={request}
+            />
+          )}
           {slashCommandJSX}
         </div>
       </div>

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -316,6 +316,20 @@ const useStore = create<Store>()((set, get, api) => ({
       }
     });
 
+    // Register toolApproval handler for backend tool approval requests
+    const { messageBus } = get();
+    if (messageBus) {
+      messageBus.registerHandler('toolApproval', async (data: any) => {
+        const { toolUse, category } = data;
+        const sessionId = get().selectedSessionId;
+        if (!sessionId) {
+          return { approved: false, denyReason: 'No active session' };
+        }
+        const { approveToolUse } = get();
+        return approveToolUse({ sessionId, toolUse, category });
+      });
+    }
+
     set({ initialized: true });
   },
 

--- a/src/renderer/store/slices/session.ts
+++ b/src/renderer/store/slices/session.ts
@@ -2,6 +2,27 @@ import React from 'react';
 import type { StateCreator } from 'zustand';
 import type { NormalizedMessage } from '../../client/types/message';
 
+// Tool approval types
+export type ApprovalResult =
+  | 'approve_once'
+  | 'approve_always_edit'
+  | 'approve_always_tool'
+  | 'deny';
+
+export interface ToolUse {
+  id: string;
+  name: string;
+  params: Record<string, any>;
+}
+
+export type ApprovalCategory = 'write' | 'bash' | 'mcp' | 'other';
+
+export interface ApprovalModalState {
+  toolUse: ToolUse;
+  category?: ApprovalCategory;
+  resolve: (result: ApprovalResult, params?: Record<string, unknown>) => void;
+}
+
 type WorkspaceId = string;
 type SessionId = string;
 
@@ -113,6 +134,9 @@ export interface SessionSliceState {
 
   // Agent progress state for sub-agent real-time display (indexed by parentToolUseId)
   agentProgressMap: Record<string, AgentProgressState>;
+
+  // Tool approval state (session-scoped)
+  approvalBySession: Record<SessionId, ApprovalModalState | null>;
 }
 
 export interface SessionSliceActions {
@@ -150,6 +174,19 @@ export interface SessionSliceActions {
   }) => void;
   clearAgentProgress: (toolUseId: string) => void;
   clearAllAgentProgress: () => void;
+
+  // Tool approval actions
+  approveToolUse: (params: {
+    sessionId: string;
+    toolUse: ToolUse;
+    category?: ApprovalCategory;
+  }) => Promise<{
+    approved: boolean;
+    params?: Record<string, unknown>;
+    denyReason?: string;
+  }>;
+  getApproval: (sessionId: string) => ApprovalModalState | null;
+  clearApproval: (sessionId: string) => void;
 }
 
 export type SessionSlice = SessionSliceState & SessionSliceActions;
@@ -174,6 +211,9 @@ export const createSessionSlice: StateCreator<
 
   // Initial agent progress state
   agentProgressMap: {},
+
+  // Initial tool approval state
+  approvalBySession: {},
 
   getSessionProcessing: (sessionId: string): SessionProcessingState => {
     const { sessionProcessing } = get();
@@ -291,5 +331,70 @@ export const createSessionSlice: StateCreator<
 
   clearAllAgentProgress: () => {
     set({ agentProgressMap: {} });
+  },
+
+  // Tool approval actions
+  approveToolUse: (params: {
+    sessionId: string;
+    toolUse: ToolUse;
+    category?: ApprovalCategory;
+  }): Promise<{
+    approved: boolean;
+    params?: Record<string, unknown>;
+    denyReason?: string;
+  }> => {
+    const { sessionId, toolUse, category } = params;
+
+    return new Promise((resolve) => {
+      set((state) => ({
+        approvalBySession: {
+          ...state.approvalBySession,
+          [sessionId]: {
+            toolUse,
+            category,
+            resolve: (
+              result: ApprovalResult,
+              resultParams?: Record<string, unknown>,
+            ) => {
+              // Clear approval state
+              set((s) => ({
+                approvalBySession: {
+                  ...s.approvalBySession,
+                  [sessionId]: null,
+                },
+              }));
+
+              const isApproved = result !== 'deny';
+
+              // Extract denyReason if denied
+              let denyReason: string | undefined;
+              if (!isApproved && resultParams?.denyReason) {
+                denyReason = resultParams.denyReason as string;
+              }
+
+              resolve({
+                approved: isApproved,
+                params: isApproved ? resultParams : undefined,
+                denyReason,
+              });
+            },
+          },
+        },
+      }));
+    });
+  },
+
+  getApproval: (sessionId: string): ApprovalModalState | null => {
+    const { approvalBySession } = get();
+    return approvalBySession[sessionId] || null;
+  },
+
+  clearApproval: (sessionId: string) => {
+    set((state) => ({
+      approvalBySession: {
+        ...state.approvalBySession,
+        [sessionId]: null,
+      },
+    }));
   },
 });


### PR DESCRIPTION
Implemented a tool approval system that displays an inline panel when AI attempts to use tools requiring user permission, with options to approve once, approve always, or deny with feedback.