### PR TITLE
fix: adjust overflow behavior in chat panel

### DIFF
--- a/src/renderer/components/layout/AppLayout.tsx
+++ b/src/renderer/components/layout/AppLayout.tsx
@@ -85,8 +85,9 @@ export function AppLayoutChatPanel({ children }: { children: ReactNode }) {
       id={AppLayoutPanelId.ChatPanel}
       minSize={CHAT_PANEL_MIN_SIZE}
       panelRef={panelRefs[AppLayoutPanelId.ChatPanel]}
+      className="overflow-hidden"
     >
-      <div className="ml-2 h-full overflow-hidden rounded-lg bg-(--bg-primary) pb-2">
+      <div className="ml-2 h-full rounded-lg bg-(--bg-primary) pb-2">
         {children}
       </div>
     </Panel>


### PR DESCRIPTION
Moved overflow-hidden class from inner div to outer Panel component to fix scrolling behavior in the chat panel.

<img width="1260" height="1732" alt="CleanShot 2026-01-27 at 14 44 35@2x" src="https://github.com/user-attachments/assets/fdb93682-796b-454d-8019-b9661e336c52" />
