### PR TITLE
ci: add typecheck dependency to build-mac-dev

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
         run: npm run typecheck
 
   build-mac-dev:
+    needs: typecheck
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Added a dependency on the typecheck job for the build-mac-dev workflow job to ensure type checking passes before the build step starts.