### PR TITLE
fix: resolve terminal sizing on panel toggle

### DIFF
--- a/docs/designs/2026-01-30-terminal-resize-on-panel-toggle.md
+++ b/docs/designs/2026-01-30-terminal-resize-on-panel-toggle.md
@@ -1,0 +1,97 @@
+# Terminal Resize on Panel Toggle Fix
+
+**Date:** 2026-01-30
+
+## Context
+
+When the ContentPanel is collapsed by default and later toggled open via the Terminal button in ActivityBar, the terminal renders incorrectly with text displaying vertically (one character per line) instead of horizontally. This is a classic xterm.js sizing/fit issue where `fitAddon.fit()` calculates wrong column/row dimensions.
+
+## Discussion
+
+### Root Cause Analysis
+
+1. **Initialization timing issue**: The terminal initialization effect only runs when `isActive` is true, but the container has incorrect dimensions (16px width) during panel transition/animation.
+
+2. **ResizeObserver setup timing**: The separate resize effect runs before the terminal instance exists because:
+   - `terminalInstances` is a JavaScript `Map`
+   - Mutating a Map via `.set()` doesn't trigger React re-render
+   - The resize effect returns early when `hasInstance: false`
+   - After instance creation in `initialize()`, the resize effect doesn't re-run
+
+3. **Observed behavior from debug logs**:
+   ```
+   Container dimensions: 16 x 891 (width only 16px - panel collapsed/animating)
+   fitAddon.fit() called - cols: 2 rows: 49 (calculated 2 columns based on 16px)
+   Resize effect - hasInstance: false (effect ran before instance existed)
+   ```
+
+### Attempted Solutions
+
+1. **First attempt**: Changed dimension-waiting from polling `setTimeout` to `ResizeObserver` - didn't solve the core issue because the resize effect still couldn't set up properly.
+
+2. **Final solution**: Move ResizeObserver setup inside the initialization function itself, right after `initializedRef.current = true`.
+
+## Approach
+
+Set up the ResizeObserver for panel resize handling inside the `initialize()` function, immediately after the terminal is fully initialized. This ensures:
+
+1. The ResizeObserver is created after the terminal instance exists
+2. It captures resize events when the panel expands from collapsed state
+3. `fitAddon.fit()` is called with correct container dimensions
+
+## Architecture
+
+### Before (Broken Flow)
+```
+1. Init effect runs (isActive: true)
+2. Resize effect runs → instance doesn't exist → returns early (no ResizeObserver)
+3. initialize() creates terminal with wrong dimensions (16px width → 2 cols)
+4. Panel expands → no ResizeObserver to catch resize → terminal stays broken
+```
+
+### After (Fixed Flow)
+```
+1. Init effect runs (isActive: true)
+2. initialize() waits for valid dimensions via ResizeObserver
+3. Terminal created with available dimensions
+4. ResizeObserver set up immediately after initialization
+5. Panel expands → ResizeObserver fires → fitAddon.fit() → correct dimensions
+```
+
+### Key Code Changes in TerminalPane.tsx
+
+1. **Removed separate resize effect** that depended on `terminalInstances` Map changes
+
+2. **Added ResizeObserver inside initialize()** after `initializedRef.current = true`:
+   ```typescript
+   initializedRef.current = true;
+
+   // Set up ResizeObserver for panel resize handling
+   let resizeTimeout: ReturnType<typeof setTimeout> | null = null;
+   const resizeObserver = new ResizeObserver(() => {
+     if (resizeTimeout) clearTimeout(resizeTimeout);
+     resizeTimeout = setTimeout(() => {
+       if (container.clientWidth > 0 && container.clientHeight > 0) {
+         fitAddon.fit();
+         if (instance.ptyId && xterm.cols > 0 && xterm.rows > 0) {
+           ipcMainCaller.terminal.resize({
+             ptyId: instance.ptyId,
+             cols: xterm.cols,
+             rows: xterm.rows,
+           });
+         }
+       }
+     }, 50);
+   });
+   resizeObserver.observe(container);
+
+   // Store cleanup for ResizeObserver
+   const originalCleanup = instance.cleanup;
+   instance.cleanup = () => {
+     if (resizeTimeout) clearTimeout(resizeTimeout);
+     resizeObserver.disconnect();
+     originalCleanup?.();
+   };
+   ```
+
+3. **Cleanup handling**: ResizeObserver cleanup is chained with existing instance cleanup to ensure proper resource disposal.

--- a/src/renderer/components/ContentPanel/panes/TerminalPane.tsx
+++ b/src/renderer/components/ContentPanel/panes/TerminalPane.tsx
@@ -271,24 +271,12 @@ export function TerminalPane({ tab, isActive }: TerminalPaneProps) {
 
   // Initialize terminal
   useEffect(() => {
-    logger.debug(
-      '[ContentPanel:TerminalPane] Init effect - isActive:',
-      isActive,
-      'tabId:',
-      tab.id,
-      'hasContainer:',
-      !!containerRef.current,
-    );
-
     if (!isActive || !containerRef.current) {
       return;
     }
 
     // If already initialized, just fit and focus
     if (initializedRef.current && terminalInstances.has(tab.id)) {
-      logger.debug(
-        '[ContentPanel:TerminalPane] Already initialized, fitting and focusing',
-      );
       const instance = terminalInstances.get(tab.id);
       instance?.fitAddon.fit();
       instance?.xterm.focus();
@@ -297,30 +285,33 @@ export function TerminalPane({ tab, isActive }: TerminalPaneProps) {
 
     const container = containerRef.current;
     let disposed = false;
-    let mountTimeout: ReturnType<typeof setTimeout> | null = null;
+    let dimensionObserver: ResizeObserver | null = null;
 
     const initialize = async () => {
       if (disposed) return;
 
-      // Wait for container to have dimensions
+      // Wait for container to have dimensions via ResizeObserver
       if (container.clientWidth === 0 || container.clientHeight === 0) {
-        logger.debug(
-          '[ContentPanel:TerminalPane] Container has no dimensions, waiting...',
-        );
-        mountTimeout = setTimeout(initialize, 50);
+        dimensionObserver = new ResizeObserver((entries) => {
+          const entry = entries[0];
+          if (
+            entry &&
+            entry.contentRect.width > 0 &&
+            entry.contentRect.height > 0
+          ) {
+            dimensionObserver?.disconnect();
+            dimensionObserver = null;
+            if (!disposed) {
+              initialize();
+            }
+          }
+        });
+        dimensionObserver.observe(container);
         return;
       }
 
-      logger.debug(
-        '[ContentPanel:TerminalPane] Container dimensions:',
-        container.clientWidth,
-        'x',
-        container.clientHeight,
-      );
-
       try {
         const { xterm, fitAddon, serializeAddon } = createXTermInstance(isDark);
-        logger.debug('[ContentPanel:TerminalPane] XTerm instance created');
 
         xterm.open(container);
         fitAddon.fit();
@@ -490,6 +481,33 @@ export function TerminalPane({ tab, isActive }: TerminalPaneProps) {
 
         initializedRef.current = true;
 
+        // Set up ResizeObserver for panel resize handling
+        let resizeTimeout: ReturnType<typeof setTimeout> | null = null;
+        const resizeObserver = new ResizeObserver(() => {
+          if (resizeTimeout) clearTimeout(resizeTimeout);
+          resizeTimeout = setTimeout(() => {
+            if (container.clientWidth > 0 && container.clientHeight > 0) {
+              fitAddon.fit();
+              if (instance.ptyId && xterm.cols > 0 && xterm.rows > 0) {
+                ipcMainCaller.terminal.resize({
+                  ptyId: instance.ptyId,
+                  cols: xterm.cols,
+                  rows: xterm.rows,
+                });
+              }
+            }
+          }, 50);
+        });
+        resizeObserver.observe(container);
+
+        // Store cleanup for ResizeObserver
+        const originalCleanup = instance.cleanup;
+        instance.cleanup = () => {
+          if (resizeTimeout) clearTimeout(resizeTimeout);
+          resizeObserver.disconnect();
+          originalCleanup?.();
+        };
+
         // Start cooldown timer - don't save until after initial PTY output
         saveAllowedRef.current = false;
         setTimeout(() => {
@@ -515,7 +533,7 @@ export function TerminalPane({ tab, isActive }: TerminalPaneProps) {
 
     return () => {
       disposed = true;
-      if (mountTimeout) clearTimeout(mountTimeout);
+      if (dimensionObserver) dimensionObserver.disconnect();
     };
   }, [
     isActive,
@@ -527,45 +545,6 @@ export function TerminalPane({ tab, isActive }: TerminalPaneProps) {
     scheduleSave,
     saveTerminalState,
   ]);
-
-  // Handle resize
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const instance = terminalInstances.get(tab.id);
-    if (!instance?.xterm || !instance?.fitAddon) return;
-
-    const container = containerRef.current;
-    const { xterm, fitAddon } = instance;
-
-    let resizeTimeout: ReturnType<typeof setTimeout> | null = null;
-    const resizeObserver = new ResizeObserver(() => {
-      if (resizeTimeout) clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(() => {
-        if (
-          initializedRef.current &&
-          container.clientWidth > 0 &&
-          container.clientHeight > 0
-        ) {
-          fitAddon.fit();
-          if (instance.ptyId && xterm.cols > 0 && xterm.rows > 0) {
-            ipcMainCaller.terminal.resize({
-              ptyId: instance.ptyId,
-              cols: xterm.cols,
-              rows: xterm.rows,
-            });
-          }
-        }
-      }, 50);
-    });
-
-    resizeObserver.observe(container);
-
-    return () => {
-      if (resizeTimeout) clearTimeout(resizeTimeout);
-      resizeObserver.disconnect();
-    };
-  }, [tab.id, terminalInstances]);
 
   // Save state on tab switch (when becoming inactive)
   useEffect(() => {


### PR DESCRIPTION
Fixed terminal rendering issue where text displays vertically when panel toggles open. Moved ResizeObserver setup into initialization function to ensure proper dimension handling during panel expansion.