### PR TITLE
style: use popover background for tab menu

### DIFF
--- a/src/renderer/components/ContentPanel/ContentTabBar.tsx
+++ b/src/renderer/components/ContentPanel/ContentTabBar.tsx
@@ -314,7 +314,7 @@ function AddTabButton() {
       {isOpen && (
         <div
           ref={menuRef}
-          className="absolute top-full left-0 mt-1 py-1 rounded-md shadow-lg z-50 bg-muted border border-border min-w-[120px]"
+          className="absolute top-full left-0 mt-1 py-1 rounded-md shadow-lg z-50 bg-popover border border-border min-w-[120px]"
         >
           {TAB_TYPE_OPTIONS.map((option) => {
             const disabled = isTypeDisabled(option.type);


### PR DESCRIPTION
Changed the background class of the add tab menu dropdown from bg-muted to bg-popover for consistent styling with the design system.