### PR TITLE
style: update settings menu item styling

### DIFF
--- a/src/renderer/components/settings/SettingsMenu.tsx
+++ b/src/renderer/components/settings/SettingsMenu.tsx
@@ -69,7 +69,7 @@ export const SettingsMenu = ({
             <button
               key={item.id}
               className={cn(
-                'w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors cursor-pointer rounded-r-[6px] mx-2',
+                'w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors cursor-pointer rounded-[6px] mx-2',
                 isActive
                   ? 'bg-background text-foreground border-l-2 border-t border-b border-border'
                   : 'text-muted-foreground hover:text-foreground',


### PR DESCRIPTION
Changed border radius from rounded-[6px] to rounded-r-[6px] and added border styling for active state in settings menu items.

before:
<img width="239" height="126" alt="Electron 2026-02-02 13 38 41" src="https://github.com/user-attachments/assets/0150b2c7-3398-4967-9aef-9d1b37c885ae" />

after:
<img width="239" height="134" alt="Electron 2026-02-02 13 39 49" src="https://github.com/user-attachments/assets/8d7c0d4e-af62-48d4-87f5-b0c359971f82" />
