### PR TITLE
style: change modal background to popover

### DIFF
--- a/src/renderer/components/Onboarding/OnboardingModal.tsx
+++ b/src/renderer/components/Onboarding/OnboardingModal.tsx
@@ -25,7 +25,7 @@ export const OnboardingModal = () => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       {/* Modal container */}
-      <div className="relative flex flex-col rounded-lg shadow-xl overflow-hidden bg-muted border border-border w-[640px] max-h-[80vh]">
+      <div className="relative flex flex-col rounded-lg shadow-xl overflow-hidden bg-popover border border-border w-[640px] max-h-[80vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">
           <h2 className="text-lg font-semibold text-foreground">


### PR DESCRIPTION
Updated OnboardingModal to use popover background instead of muted background for better visual consistency.

Fix
<img width="1266" height="866" alt="image" src="https://github.com/user-attachments/assets/5de11d7f-c5e3-48a6-bc10-c23e6fd79e26" />

<img width="1266" height="866" alt="image" src="https://github.com/user-attachments/assets/e478b2eb-4eef-4a65-a767-856ab0e3902e" />
