### PR TITLE
refactor: hide reload options in production

### DIFF
--- a/src/main/core/app.ts
+++ b/src/main/core/app.ts
@@ -183,10 +183,7 @@ export class MainApp {
         label: 'View',
         submenu: [
           ...(is.dev
-            ? [
-                { role: 'reload' as const },
-                { role: 'forceReload' as const },
-              ]
+            ? [{ role: 'reload' as const }, { role: 'forceReload' as const }]
             : []),
           { role: 'toggleDevTools' },
           { type: 'separator' },


### PR DESCRIPTION
Conditionally show reload and forceReload menu items only in development mode to improve production UX.