### PR TITLE
fix: disable context cache in server mode

### DIFF
--- a/src/main/server/create.ts
+++ b/src/main/server/create.ts
@@ -63,6 +63,7 @@ export async function createNeovateServer(
 
   const argv = await parseArgs([
     'server',
+    '--disable-context-cache',
     '--port',
     String(port),
     '--host',


### PR DESCRIPTION
Added --disable-context-cache flag to server startup arguments to improve performance.

wait for https://github.com/neovateai/neovate-code/pull/747
Close https://github.com/neovateai/neovate-code-desktop/issues/123