### PR TITLE
feat: add task cancellation state and UI indicators

### DIFF
--- a/src/renderer/components/messages/TaskMessage/TaskCancelled.tsx
+++ b/src/renderer/components/messages/TaskMessage/TaskCancelled.tsx
@@ -1,0 +1,22 @@
+import { Ban } from 'lucide-react';
+import type { ToolUsePart } from '../../../client/types/message';
+
+interface TaskCancelledProps {
+  toolUse: ToolUsePart;
+}
+
+export function TaskCancelled({ toolUse }: TaskCancelledProps) {
+  const agentType = toolUse.input?.subagent_type || 'Agent';
+  const description = toolUse.input?.description;
+
+  return (
+    <div className="border-l-2 border-muted-foreground/40 pl-3 py-1">
+      <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
+        <Ban className="size-3.5" />
+        <span className="font-medium">{agentType}</span>
+        {description && <span>({description})</span>}
+        <span className="italic">Cancelled</span>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/messages/TaskMessage/index.tsx
+++ b/src/renderer/components/messages/TaskMessage/index.tsx
@@ -3,6 +3,7 @@ import type {
   ToolUsePart,
 } from '../../../client/types/message';
 import { useStore } from '../../../store';
+import { TaskCancelled } from './TaskCancelled';
 import { TaskCompleted } from './TaskCompleted';
 import { TaskInProgress } from './TaskInProgress';
 import { TaskStarting } from './TaskStarting';
@@ -20,6 +21,12 @@ export function TaskMessage({ toolUse, toolResult }: TaskMessageProps) {
   const agentProgressMap = useStore((s) => s.agentProgressMap);
   const progressData = agentProgressMap[toolUse.id];
 
+  const selectedSessionId = useStore((s) => s.selectedSessionId);
+  const sessionProcessing = useStore((s) =>
+    selectedSessionId ? s.sessionProcessing[selectedSessionId] : null,
+  );
+  const isProcessing = sessionProcessing?.status === 'processing';
+
   // Priority: toolResult exists = completed
   if (toolResult) {
     return <TaskCompleted toolUse={toolUse} toolResult={toolResult} />;
@@ -28,6 +35,11 @@ export function TaskMessage({ toolUse, toolResult }: TaskMessageProps) {
   // Running state - has progress data with running status
   if (progressData?.status === 'running') {
     return <TaskInProgress toolUse={toolUse} progressData={progressData} />;
+  }
+
+  // Cancelled state - session is no longer processing but no result was received
+  if (!isProcessing) {
+    return <TaskCancelled toolUse={toolUse} />;
   }
 
   // Starting state - no progress yet or just started

--- a/src/renderer/components/messages/ToolMessage.tsx
+++ b/src/renderer/components/messages/ToolMessage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { diffLines } from 'diff';
+import { useStore } from '../../store';
 import { DiffViewer } from './DiffViewer';
 import { TaskMessage } from './TaskMessage';
 import type { TodoItemProps } from './TodoItem';
@@ -108,6 +109,14 @@ function calculateDiffStats(
 export function ToolMessage({ pair }: ToolMessageProps) {
   const { toolUse, toolResult } = pair;
 
+  const selectedSessionId = useStore((s) => s.selectedSessionId);
+  const isProcessing = useStore(
+    (s) =>
+      (selectedSessionId
+        ? s.sessionProcessing[selectedSessionId]?.status
+        : null) === 'processing',
+  );
+
   // Delegate to TaskMessage for task tool (sub-agent)
   if (toolUse.name === 'task') {
     return <TaskMessage toolUse={toolUse} toolResult={toolResult} />;
@@ -171,9 +180,14 @@ export function ToolMessage({ pair }: ToolMessageProps) {
               </span>
             );
           })()}
-        {!toolResult && (
+        {!toolResult && isProcessing && (
           <span className="ml-2 text-xs text-amber-500 italic">
             (pending...)
+          </span>
+        )}
+        {!toolResult && !isProcessing && (
+          <span className="ml-2 text-xs text-muted-foreground italic">
+            (cancelled)
           </span>
         )}
       </div>

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -935,6 +935,9 @@ const useStore = create<Store>()((set, get, api) => ({
       retryInfo: null,
       error: null,
     });
+
+    // Clear agent progress state so sub-agent UIs stop showing loading
+    get().clearAllAgentProgress();
   },
 
   clearSession: (sessionId: string) => {


### PR DESCRIPTION
Added cancellation state handling for tasks with visual indicators and updated the store to clear agent progress on session completion.

<img width="372" height="308" alt="Cursor 2026-02-12 12 35 34" src="https://github.com/user-attachments/assets/b60b471b-5023-48c0-bf26-44d8b94fcab7" />
