### PR TITLE
fix: spawn PTY as login shell to load full PATH

### DIFF
--- a/src/main/pty/manager.ts
+++ b/src/main/pty/manager.ts
@@ -89,7 +89,7 @@ class PTYManager {
     );
 
     try {
-      const ptyProcess = pty.spawn(shell, [], {
+      const ptyProcess = pty.spawn(shell, ['-l'], {
         name: 'xterm-256color',
         cols,
         rows,


### PR DESCRIPTION
## Summary

- Spawn PTY shell with `-l` flag to start as login shell, ensuring `~/.zprofile` and other login profile files are sourced
- Fixes terminal not finding `node`/`npm` when the app is launched from Finder/Dock instead of a terminal

Closes #101

## Test plan

- [ ] Launch app from Finder/Dock (not terminal)
- [ ] Open Terminal, run `echo $PATH` — should include homebrew/nvm/volta paths
- [ ] Run `which node` and `which npm` — should resolve correctly
- [ ] Run `node --version` — should match the version configured via nvm/volta