### PR TITLE
feat: add configurable updater provider for MainApp

### DIFF
--- a/docs/designs/2026-02-12-configurable-updater-provider.md
+++ b/docs/designs/2026-02-12-configurable-updater-provider.md
@@ -1,0 +1,67 @@
+# Configurable Updater Provider for MainApp
+
+**Date:** 2026-02-12
+
+## Context
+
+The current `UpdaterService` does not support runtime configuration of the update provider or feedURL. It relies entirely on build-time `publish` config from electron-builder (GitHub provider for production, generic provider for local builds). As `MainApp` is being prepared for external consumption, consumers need the ability to configure their own update server at construction time.
+
+## Discussion
+
+**Config shape:** We use `FeedURLOptions` (derived from `AppUpdater['setFeedURL']` parameter type) wrapped in an `UpdaterOptions` interface. The interface wrapper allows future extensibility (e.g., adding behavior options) without changing the `MainAppOptions` shape.
+
+**Async feedURL resolution:** The feedURL may need to be resolved asynchronously (e.g., fetched from a config server). Three approaches were evaluated:
+
+1. **Sync only** — consumer resolves before constructing `MainApp`. Simple but pushes async burden to the consumer.
+2. **Async function support** — accept `AllPublishOptions | (() => Promise<AllPublishOptions>)`, awaited during `init()` before the first auto-check. Keeps the init flow linear.
+3. **Deferred `configureUpdater()` method** — rejected because it creates a race condition with auto-check on startup. The updater would need to track "configured vs not configured" state and gate the check interval, adding significant state flow complexity.
+
+**Mutability:** Dynamic `setFeedURL` after init was rejected. Changing the provider at runtime makes the update state flow (checking → downloading → downloaded → installing) difficult to control. Config is set once and immutable.
+
+**Default behavior:** When no updater config is provided, the updater falls back to build-time electron-builder config — preserving current behavior for existing consumers.
+
+## Approach
+
+Add an `updater` field to `MainAppOptions` that accepts an `UpdaterOptions` object with an optional `feedURL` property (`FeedURLOptions | (() => Promise<FeedURLOptions>)`). The config flows through `MainApp` to `UpdaterService.init()`, where it is resolved (awaited if async) and applied via `autoUpdater.setFeedURL()`. The updater init is fire-and-forget — it does not block renderer loading.
+
+- Provider/feedURL only — no behavior options (autoDownload, checkInterval, etc.)
+- Set once at construction, immutable after init
+- Non-blocking init: renderer loads immediately, updater resolves config in the background
+
+## Architecture
+
+**Type changes** (`src/main/core/types.ts`):
+```typescript
+import type { AppUpdater } from 'electron-updater';
+
+export type FeedURLOptions = Parameters<AppUpdater['setFeedURL']>[0];
+
+export interface UpdaterOptions {
+  feedURL?: FeedURLOptions | (() => Promise<FeedURLOptions>);
+}
+
+export interface MainAppOptions {
+  neovateOptions?: NeovateOptions;
+  updater?: UpdaterOptions;
+}
+```
+
+**MainApp** (`src/main/core/app.ts`):
+- Store `updater` from constructor
+- Pass to `updaterService.init(mainWindow, updater)` in `createWindow()` — fire-and-forget (not awaited)
+
+**UpdaterService** (`src/main/updater/service.ts`):
+- `init()` accepts optional `UpdaterOptions`
+- If provided: resolve feedURL (await if function), call `autoUpdater.setFeedURL(resolved)`
+- Then proceed with existing setup (event listeners, scheduled checks)
+- Re-entry (macOS activate): updates `mainWindow` reference, re-runs `startScheduledChecks()` (idempotent)
+
+**Init flow:**
+```
+MainApp.createWindow()
+  → loadURL() (renderer loads immediately)
+  → updaterService.init(mainWindow, updater) (fire-and-forget)
+    → if feedURL: resolve → autoUpdater.setFeedURL(resolved)
+    → setup event listeners (guarded by isAutoUpdaterSetup)
+    → start scheduled checks (guarded by checkInterval)
+```

--- a/src/main/core/app.ts
+++ b/src/main/core/app.ts
@@ -27,9 +27,11 @@ export class MainApp {
   private mainWindow: BrowserWindow | null = null;
   private tray: Tray | null = null;
   private neovateOptions?: NeovateOptions;
+  private updater?: MainAppOptions['updater'];
 
   constructor(options?: MainAppOptions) {
     this.neovateOptions = options?.neovateOptions;
+    this.updater = options?.updater;
   }
 
   async start(): Promise<void> {
@@ -44,7 +46,7 @@ export class MainApp {
     this.registerIpcHandlers();
     this.createMenu();
     this.createTray();
-    this.createWindow();
+    await this.createWindow();
     this.registerLifecycleHandlers();
   }
 
@@ -279,7 +281,7 @@ export class MainApp {
     this.tray.setContextMenu(contextMenu);
   }
 
-  private createWindow(): void {
+  private async createWindow(): Promise<void> {
     this.mainWindow = new BrowserWindow({
       width: 1200,
       height: 800,
@@ -301,8 +303,7 @@ export class MainApp {
     // Initialize services after window is created
     if (this.mainWindow) {
       browserWindowManager.setMainWindow(this.mainWindow);
-      updaterService.init(this.mainWindow);
-      // 设置 bridgeServer 的 webContents，以便 extension 可以通知 renderer
+      updaterService.init(this.mainWindow, this.updater);
       bridgeServer.connect2renderer(this.mainWindow.webContents);
     }
 
@@ -330,7 +331,7 @@ export class MainApp {
 
     app.on('activate', () => {
       if (this.mainWindow === null) {
-        this.createWindow();
+        this.createWindow().catch(console.error);
       }
     });
 

--- a/src/main/core/types.ts
+++ b/src/main/core/types.ts
@@ -1,4 +1,5 @@
 import type { Plugin, runNeovate } from '@neovate/code';
+import type { AppUpdater } from 'electron-updater';
 
 export type { Plugin as NeovatePlugin };
 
@@ -10,6 +11,13 @@ export type NeovateOptions = Partial<
   Omit<Parameters<typeof runNeovate>[0], 'productName' | 'version' | 'argv'>
 >;
 
+export type FeedURLOptions = Parameters<AppUpdater['setFeedURL']>[0];
+
+export interface UpdaterOptions {
+  feedURL?: FeedURLOptions | (() => Promise<FeedURLOptions>);
+}
+
 export interface MainAppOptions {
   neovateOptions?: NeovateOptions;
+  updater?: UpdaterOptions;
 }

--- a/src/main/updater/service.ts
+++ b/src/main/updater/service.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import type { UpdaterOptions } from '../core/types';
 import {
   exposeAsMainHandlers,
   getRendererCaller,
@@ -22,12 +23,32 @@ class UpdaterService {
     percent: number;
   } | null = null;
 
-  init(mainWindow: BrowserWindow): void {
+  async init(
+    mainWindow: BrowserWindow,
+    updaterOptions?: UpdaterOptions,
+  ): Promise<void> {
     this.mainWindow = mainWindow;
+
     if (!this.isAutoUpdaterSetup) {
+      if (updaterOptions?.feedURL) {
+        try {
+          const resolved =
+            typeof updaterOptions.feedURL === 'function'
+              ? await updaterOptions.feedURL()
+              : updaterOptions.feedURL;
+          autoUpdater.setFeedURL(resolved);
+        } catch (err) {
+          console.error(
+            '[UpdaterService] Failed to resolve feedURL, using build-time config:',
+            (err as Error).message,
+          );
+        }
+      }
+
       this.setupAutoUpdater();
       this.isAutoUpdaterSetup = true;
     }
+
     this.startScheduledChecks();
   }
 


### PR DESCRIPTION
## Summary

- Add `UpdaterOptions` to `MainAppOptions` allowing consumers to configure a custom update feed URL (sync value or async factory)
- Make updater init fire-and-forget so it doesn't block renderer loading
- Restore original if-block structure in `UpdaterService.init()` so `startScheduledChecks()` runs on every call (macOS activate re-entry)
- Add design document for the configurable updater provider feature

## Test plan

- [ ] Verify app starts without blank window delay
- [ ] Verify updater still checks for updates on schedule
- [ ] Verify custom `feedURL` (sync) is applied via `setFeedURL()`
- [ ] Verify async `feedURL` factory resolves and applies correctly
- [ ] Verify fallback to build-time config when no `feedURL` provided
- [ ] Run `npm run typecheck`