### PR TITLE
feat: add channel support to UpdaterOptions

### DIFF
--- a/src/main/core/types.ts
+++ b/src/main/core/types.ts
@@ -15,6 +15,7 @@ export type FeedURLOptions = Parameters<AppUpdater['setFeedURL']>[0];
 
 export interface UpdaterOptions {
   feedURL?: FeedURLOptions | (() => Promise<FeedURLOptions>);
+  channel?: string;
 }
 
 export interface MainAppOptions {

--- a/src/main/updater/service.ts
+++ b/src/main/updater/service.ts
@@ -30,6 +30,10 @@ class UpdaterService {
     this.mainWindow = mainWindow;
 
     if (!this.isAutoUpdaterSetup) {
+      if (updaterOptions?.channel) {
+        autoUpdater.channel = updaterOptions.channel;
+      }
+
       if (updaterOptions?.feedURL) {
         try {
           const resolved =


### PR DESCRIPTION
## Summary
- Add optional `channel` field to `UpdaterOptions` interface and apply it in `UpdaterService.init()` so consumers can control which yml file (e.g. `beta-mac.yml` vs `latest-mac.yml`) electron-updater requests from the feed server.