### PR TITLE
fix(ChatInput): arrow keys move cursor instead of navigating history

### DIFF
--- a/src/renderer/hooks/useInputHandlers.ts
+++ b/src/renderer/hooks/useInputHandlers.ts
@@ -307,20 +307,6 @@ export function useInputHandlers({
     inputState,
   ]);
 
-  const isAtFirstLine = useCallback(() => {
-    const currentValue = valueRef.current;
-    const currentCursorPosition = cursorPositionRef.current;
-    const beforeCursor = currentValue.substring(0, currentCursorPosition);
-    return !beforeCursor.includes('\n');
-  }, []);
-
-  const isAtLastLine = useCallback(() => {
-    const currentValue = valueRef.current;
-    const currentCursorPosition = cursorPositionRef.current;
-    const afterCursor = currentValue.substring(currentCursorPosition);
-    return !afterCursor.includes('\n');
-  }, []);
-
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       const textarea = e.currentTarget;
@@ -395,7 +381,7 @@ export function useInputHandlers({
           e.preventDefault();
           return;
         }
-        if (hasSuggestions || isAtFirstLine()) {
+        if (hasSuggestions) {
           e.preventDefault();
           handleHistoryUp();
         }
@@ -403,7 +389,7 @@ export function useInputHandlers({
       }
 
       if (e.key === 'ArrowDown') {
-        if (hasSuggestions || isAtLastLine()) {
+        if (hasSuggestions) {
           e.preventDefault();
           handleHistoryDown();
         }
@@ -598,8 +584,6 @@ export function useInputHandlers({
       applyFileSuggestion,
       togglePlanMode,
       toggleThinking,
-      isAtFirstLine,
-      isAtLastLine,
     ],
   );
 


### PR DESCRIPTION
## Summary

Fixes #137 - Arrow keys now move the cursor naturally in multi-line input instead of navigating history.

## Changes

- Removed `isAtFirstLine()` and `isAtLastLine()` checks from ArrowUp/ArrowDown handlers
- ArrowUp/ArrowDown now only trigger suggestion navigation when suggestions are visible
- When editing multi-line text, arrow keys move the cursor naturally within the textarea
- History navigation remains available via Ctrl+P (up) and Ctrl+N (down)

## Behavior

| Before | After |
|--------|-------|
| ArrowUp at first line → history navigation | ArrowUp at first line → cursor stays at first line |
| ArrowDown at last line → history navigation | ArrowDown at last line → cursor stays at last line |
| No way to move cursor line-by-line in history | Arrow keys work naturally for text editing |

## Testing

- Type multiple lines in the input box
- Press ArrowUp/ArrowDown - cursor should move between lines
- History navigation still works with Ctrl+P/N
- Suggestion dropdown navigation with arrow keys still works