### PR TITLE
fix: disable pointer events on webview during panel resize drag

### DIFF
--- a/src/renderer/components/layout/AppLayoutProvider.tsx
+++ b/src/renderer/components/layout/AppLayoutProvider.tsx
@@ -238,6 +238,10 @@ export function AppLayoutPanelProvider({ children }: { children: ReactNode }) {
     for (const iframe of iframes) {
       iframe.style.pointerEvents = 'none';
     }
+    const webviews = document.getElementsByTagName('webview');
+    for (const webview of webviews) {
+      (webview as HTMLElement).style.pointerEvents = 'none';
+    }
 
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mouseup', handleMouseUp);
@@ -248,6 +252,9 @@ export function AppLayoutPanelProvider({ children }: { children: ReactNode }) {
       document.body.style.cursor = '';
       for (const iframe of iframes) {
         iframe.style.pointerEvents = '';
+      }
+      for (const webview of webviews) {
+        (webview as HTMLElement).style.pointerEvents = '';
       }
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);


### PR DESCRIPTION
## Summary

- Extends the existing iframe pointer-events fix to also cover `<webview>` elements during panel resize drag
- During a drag, `pointerEvents = 'none'` is set on all `<webview>` elements so mouse events aren't captured by the embedded browser view
- Pointer events are restored in the cleanup function when the drag ends

## Problem

When a `<webview>` is visible in the content panel, the resize handle would stop tracking the mouse because the webview's embedded iframe captured all `mousemove`/`mouseup` events before they could reach the document-level drag listeners.

## Test plan

- [ ] Open a browser tab in the content panel so a `<webview>` is visible
- [ ] Drag the resize handle on either side of the content panel — should track smoothly
- [ ] Release the mouse — panel should stay at the new width
- [ ] Confirm dragging still works with no webview present