### PR TITLE
fix: pin electron to ~40.1.x to avoid net.Socket regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "date-fns": "^4.1.0",
         "defu": "^6.1.4",
         "diff": "^8.0.3",
-        "electron": "^40.1.0",
+        "electron": "~40.1.0",
         "electron-builder": "^26.7.0",
         "electron-vite": "^5.0.0",
         "gpt-tokenizer": "^3.4.0",
@@ -2815,6 +2815,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "date-fns": "^4.1.0",
     "defu": "^6.1.4",
     "diff": "^8.0.3",
-    "electron": "^40.1.0",
+    "electron": "~40.1.0",
     "electron-builder": "^26.7.0",
     "electron-vite": "^5.0.0",
     "gpt-tokenizer": "^3.4.0",


### PR DESCRIPTION
## Summary

- Pin `electron` from `^40.1.0` to `~40.1.0` to prevent resolving to 40.3.0
- Electron 40.3.0 has a regression where `net.Socket.connect()` in Extension Host subprocess never fires any events (connect, error, close, timeout)
- This causes the bridge server TCP connection to silently fail, so clicking files in file tree does nothing (code-server extension can't connect to port 45000)

## Root Cause

In Electron 40.3.0, `net.Socket.connect()` called from the Extension Host child process doesn't trigger the connect syscall at OS level. Even `process.getBuiltinModule("net")` exhibits the same behavior. Verified via `lsof` — no socket is created.

Electron 40.1.0 works correctly.

## Test plan

- [ ] Run `npm run dev`, verify bridge server connects (`ExtensionBridgeServer Received { operationType: 'ping' }` in logs)
- [ ] Click a file in file tree, verify it opens in the editor